### PR TITLE
Compute word frequencies on a server

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@ This program reads all files in a given directory and counts the most common wor
 The input files are dracula.txt and frankenstein.txt.
 
 The results are [('the', 12483), ('and', 9018), ('i', 7692), ('to', 6919), ('of', 6517)], which looks reasonable.
+
+The transmission protocol is as follows:
+
+send_text()
+1. client sends header - send_header()
+2. server stores header, sends res - sendall()
+3. client checks res == header
+4. client sends payload - send_payload()
+5. server stores payload, sends res - sendall()
+6. client checks res == payload
+
+send_dict()
+server computes word frequency
+1. server sends header - send_header()
+2. client stores header, sends res
+3. server checks res == header
+4. server sends json dump - send_json_dump()
+5. client stores json dump, sends res - sendall()
+6. server checks res == json dump

--- a/controller.py
+++ b/controller.py
@@ -21,7 +21,7 @@ class Controller:
         else:
             return False, res
 
-    def send_payload(self, msg):
+    def _send_payload(self, msg):
         self.conn.sendall(msg.payload)
         res = self.conn.recv(msg.length).decode(msg.encoding)
 
@@ -39,7 +39,7 @@ class Controller:
             raise Exception('Send header failed.')
         else:
             # continue
-            ok, res = self.send_payload(msg)
+            ok, res = self._send_payload(msg)
 
             if not ok:
                 raise Exception('Send message payload failed.')

--- a/controller.py
+++ b/controller.py
@@ -1,3 +1,4 @@
+import json
 import socket
 
 from models.message import Message
@@ -45,3 +46,28 @@ class Controller:
                 raise Exception('Send message payload failed.')
             else:
                 return ok, res
+
+    def send_dict(self, json_dict):
+        data = json.dumps(json_dict)
+        msg = Message(data, self)
+
+        ok, res = self.send_header(msg.header)
+
+        if not ok:
+            raise Exception('Send header failed.')
+        else:
+            # continue
+            self._send_payload(msg)
+
+    def receive_dict(self):
+        header = self.conn.recv(1024)
+        self.conn.sendall(header)
+        payload_size = int(header.decode('utf-8'))
+
+        # 5. client stores json dump, sends res - sendall()
+        data = self.conn.recv(payload_size)
+        self.conn.sendall(data)
+
+        json_dict = json.loads(data)
+
+        return json_dict

--- a/controller.py
+++ b/controller.py
@@ -59,6 +59,8 @@ class Controller:
             # continue
             self._send_payload(msg)
 
+            return ok, res
+
     def receive_dict(self):
         header = self.conn.recv(1024)
         self.conn.sendall(header)

--- a/controller.py
+++ b/controller.py
@@ -1,5 +1,7 @@
 import socket
 
+from models.message import Message
+
 
 class Controller:
     def __init__(self, socket_connection):
@@ -18,3 +20,28 @@ class Controller:
             return True, res
         else:
             return False, res
+
+    def send_payload(self, msg):
+        self.conn.sendall(msg.payload)
+        res = self.conn.recv(msg.length).decode(msg.encoding)
+
+        if res == msg.text:
+            return True, res
+        else:
+            return False, res
+
+    def send_text(self, text: str):
+        msg = Message(text, self)
+
+        ok, res = self.send_header(msg.header)
+
+        if not ok:
+            raise Exception('Send header failed.')
+        else:
+            # continue
+            ok, res = self.send_payload(msg)
+
+            if not ok:
+                raise Exception('Send message payload failed.')
+            else:
+                return ok, res

--- a/controller.py
+++ b/controller.py
@@ -1,0 +1,20 @@
+import socket
+
+
+class Controller:
+    def __init__(self, socket_connection):
+        self.conn = socket_connection
+
+    def send_header(self, header_to_send):
+        try:
+            self.conn.sendall(header_to_send)
+            res = self.conn.recv(1024)
+        except socket.timeout as e:
+            print(e)
+            res = None
+
+        # Verify result
+        if res == header_to_send:
+            return True, res
+        else:
+            return False, res

--- a/models/base_counter.py
+++ b/models/base_counter.py
@@ -5,16 +5,13 @@ from os.path import isfile, join
 
 from collections import Counter
 
+from server import count_word_frequencies
+
 
 class BaseCounter:
     def __init__(self, text: str = None, data_path: str = None):
         self.text = text
         self.data_path = data_path
-
-    def count_word_frequencies(self) -> Dict:
-        words = re.findall(r'\w+', self.text.lower())
-        fre_counter = Counter(words)
-        return dict(fre_counter)
 
     def count_word_frequencies_in_directory(self, top_k: int = None) -> Dict:
         mypath = self.data_path

--- a/models/base_server.py
+++ b/models/base_server.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+
+
+class BaseServer(ABC):
+    def __init__(self, server_ip, server_port):
+        self.server_ip = server_ip
+        self.server_port = server_port
+
+    @abstractmethod
+    def start(self):
+        pass

--- a/models/echo_server.py
+++ b/models/echo_server.py
@@ -1,12 +1,13 @@
 # echo-server.py
-# This code is copied from https://realpython.com/python-sockets/#echo-server
+# This code is inspired by https://realpython.com/python-sockets/#echo-server
 import socket
 
+from models.base_server import BaseServer
 
-class EchoServer:
+
+class EchoBaseServer(BaseServer):
     def __init__(self, server_ip, server_port):
-        self.server_ip = server_ip
-        self.server_port = server_port
+        super().__init__(server_ip, server_port)
 
     def start(self):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/models/echo_server.py
+++ b/models/echo_server.py
@@ -1,0 +1,22 @@
+# echo-server.py
+# This code is copied from https://realpython.com/python-sockets/#echo-server
+import socket
+
+
+class EchoServer:
+    def __init__(self, server_ip, server_port):
+        self.server_ip = server_ip
+        self.server_port = server_port
+
+    def start(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((self.server_ip, self.server_port))
+            s.listen()
+            conn, addr = s.accept()
+            with conn:
+                print(f"Connected by {addr}")
+                while True:
+                    data = conn.recv(1024)
+                    if not data:
+                        break
+                    conn.sendall(data)

--- a/models/message.py
+++ b/models/message.py
@@ -1,0 +1,19 @@
+
+
+class Message:
+    def __init__(self, text, controller):
+        self.encoding = 'utf-8'
+        self._text = text
+        self._payload = self._text.encode(self.encoding)
+        self._length = len(self._payload)
+        self._header = str(self._length).encode(self.encoding)
+        self.controller = controller
+        self.ok = False
+
+    @property
+    def text(self):
+        return self._text
+
+    @text.setter
+    def text(self, text: str):
+        self._text = text

--- a/models/message.py
+++ b/models/message.py
@@ -17,3 +17,27 @@ class Message:
     @text.setter
     def text(self, text: str):
         self._text = text
+
+    @property
+    def header(self):
+        return self._header
+
+    @header.setter
+    def header(self, header: str):
+        self._header = header
+
+    @property
+    def payload(self):
+        return self._payload
+
+    @payload.setter
+    def payload(self, payload: str):
+        self._payload = payload
+
+    @property
+    def length(self):
+        return self._length
+
+    @length.setter
+    def length(self, length: str):
+        self._length = length

--- a/server.py
+++ b/server.py
@@ -1,0 +1,68 @@
+import json
+import socket
+from collections import Counter
+import re
+
+
+def count_word_frequencies(text):
+    words = re.findall(r'\w+', text.lower())
+    fre_list = Counter(words)
+    return dict(fre_list)
+
+
+def start():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+
+        s.bind((socket.gethostname(), 50001))
+        s.listen()
+
+        while True:
+            client_socket, addr = s.accept()
+
+            # 2. server stores header, sends res - sendall()
+            data_received = client_socket.recv(1024)
+            # while socket is open
+            while data_received != b'':
+                print(f'2. I got {data_received}')
+                payload_size = int(data_received.decode('utf-8'))
+
+                client_socket.sendall(data_received)
+
+                # 5. server stores payload, sends res - sendall()
+                payload = client_socket.recv(payload_size)
+                print(f'5. I got {payload}')
+                client_socket.sendall(payload)
+
+                # server computes word frequency
+                text = payload.decode('utf-8')
+                f_list = count_word_frequencies(text)
+                print(f_list)
+
+                data = json.dumps(f_list)
+                print('Sending json dump!')
+                # 1. server sends header - send_header()
+                payload_size = len(data)
+                header = str(payload_size).encode('utf-8')
+                client_socket.sendall(header)
+
+                # 3. server checks res == header
+                res = client_socket.recv(1024)
+                print(f'3. I got {res}')
+
+                assert res == header
+
+                # 4. server sends json dump - send_json_dump()
+                payload = bytes(data, encoding="utf-8")
+                client_socket.sendall(payload)
+
+                # 6. server checks res == json dump
+                res = client_socket.recv(payload_size)
+
+                assert res == payload
+
+                # the very end, wait for next packet
+                data_received = client_socket.recv(1024)
+
+
+if __name__ == '__main__':
+    start()

--- a/server.py
+++ b/server.py
@@ -2,9 +2,10 @@ import json
 import socket
 from collections import Counter
 import re
+from typing import Dict
 
 
-def count_word_frequencies(text):
+def count_word_frequencies(text: str) -> Dict:
     words = re.findall(r'\w+', text.lower())
     fre_list = Counter(words)
     return dict(fre_list)
@@ -49,19 +50,22 @@ def start():
                 res = client_socket.recv(1024)
                 print(f'3. I got {res}')
 
-                assert res == header
+                if res != header:
+                    raise Exception('Sent message was corrupted.')
+                else:
+                    # continues
+                    # 4. server sends json dump - send_json_dump()
+                    payload = bytes(data, encoding="utf-8")
+                    client_socket.sendall(payload)
 
-                # 4. server sends json dump - send_json_dump()
-                payload = bytes(data, encoding="utf-8")
-                client_socket.sendall(payload)
+                    # 6. server checks res == json dump
+                    res = client_socket.recv(payload_size)
 
-                # 6. server checks res == json dump
-                res = client_socket.recv(payload_size)
+                    if res != payload:
+                        raise Exception('Sent message was corrupted.')
 
-                assert res == payload
-
-                # the very end, wait for next packet
-                data_received = client_socket.recv(1024)
+                    # the very end, wait for next packet
+                    data_received = client_socket.recv(1024)
 
 
 if __name__ == '__main__':

--- a/server.py
+++ b/server.py
@@ -4,6 +4,8 @@ from collections import Counter
 import re
 from typing import Dict
 
+from controller import Controller
+
 
 def count_word_frequencies(text: str) -> Dict:
     words = re.findall(r'\w+', text.lower())
@@ -19,53 +21,31 @@ def start():
 
         while True:
             client_socket, addr = s.accept()
+            controller = Controller(client_socket)
 
             # 2. server stores header, sends res - sendall()
-            data_received = client_socket.recv(1024)
+            data_received = controller.conn.recv(1024)
             # while socket is open
             while data_received != b'':
                 print(f'2. I got {data_received}')
                 payload_size = int(data_received.decode('utf-8'))
 
-                client_socket.sendall(data_received)
+                controller.conn.sendall(data_received)
 
                 # 5. server stores payload, sends res - sendall()
-                payload = client_socket.recv(payload_size)
+                payload = controller.conn.recv(payload_size)
                 print(f'5. I got {payload}')
-                client_socket.sendall(payload)
+                controller.conn.sendall(payload)
 
                 # server computes word frequency
                 text = payload.decode('utf-8')
-                f_list = count_word_frequencies(text)
-                print(f_list)
+                f_dict = count_word_frequencies(text)
+                print(f_dict)
 
-                data = json.dumps(f_list)
-                print('Sending json dump!')
-                # 1. server sends header - send_header()
-                payload_size = len(data)
-                header = str(payload_size).encode('utf-8')
-                client_socket.sendall(header)
+                controller.send_dict(f_dict)
 
-                # 3. server checks res == header
-                res = client_socket.recv(1024)
-                print(f'3. I got {res}')
-
-                if res != header:
-                    raise Exception('Sent message was corrupted.')
-                else:
-                    # continues
-                    # 4. server sends json dump - send_json_dump()
-                    payload = bytes(data, encoding="utf-8")
-                    client_socket.sendall(payload)
-
-                    # 6. server checks res == json dump
-                    res = client_socket.recv(payload_size)
-
-                    if res != payload:
-                        raise Exception('Sent message was corrupted.')
-
-                    # the very end, wait for next packet
-                    data_received = client_socket.recv(1024)
+                # the very end, wait for next packet
+                data_received = controller.conn.recv(1024)
 
 
 if __name__ == '__main__':

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -16,7 +16,7 @@ class TestController(unittest.TestCase):
         """
         def send_to_server():
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.settimeout(0.0001)
+                s.settimeout(1)
                 s.connect(('127.0.0.1', 50001))
 
                 client = Controller(s)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -3,7 +3,7 @@ import unittest
 from threading import Thread
 
 from models.message import Message
-from models.echo_server import EchoServer
+from models.echo_server import EchoBaseServer
 from controller import Controller
 
 
@@ -14,26 +14,21 @@ class TestController(unittest.TestCase):
         When send_header() to an echoing server,
         Then received message matches the original message.
         """
-        def send_to_server():
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.settimeout(1)
-                s.connect(('127.0.0.1', 50001))
-
-                client = Controller(s)
-                text = 'A message of 21 bytes'
-                msg = Message(text, client)
-
-                ok, res = client.send_header(msg._header)
-
-                self.assertTrue(ok)
-                self.assertIsNotNone(res)
-                self.assertEqual(res, b'21')
-                print(res)
-
-        echo_server = EchoServer('127.0.0.1', 50001)
+        echo_server = EchoBaseServer('127.0.0.1', 50001)
         t1 = Thread(target=echo_server.start)
         t1.start()
 
-        t2 = Thread(target=send_to_server)
-        t2.start()
-        t2.join()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(1)
+            s.connect(('127.0.0.1', 50001))
+
+            client = Controller(s)
+            text = 'A message of 21 bytes'
+            msg = Message(text, client)
+
+            ok, res = client.send_header(msg._header)
+
+            self.assertTrue(ok)
+            self.assertIsNotNone(res)
+            self.assertEqual(res, b'21')
+            print(res)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,28 @@
+import socket
+import unittest
+
+from models.message import Message
+from modles.server import Server
+from controller import Controller
+
+
+class TestController(unittest.TestCase):
+    def test_send(self):
+        """
+        Given one line of text,
+        When send() to an echoing server,
+        Then received message matches the original message.
+        """
+        text = 'A very very simple text.'
+        msg = Message(text)
+        echo_server = Server()
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.connect((echo_server.server_ip, echo_server.server_port))
+
+            client = Controller(s)
+
+            ok, res = client.send(msg)
+
+            self.assertTrue(ok)
+            self.assertIsNotNone(res)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,28 +1,39 @@
 import socket
 import unittest
+from threading import Thread
 
 from models.message import Message
-from modles.server import Server
+from models.echo_server import EchoServer
 from controller import Controller
 
 
 class TestController(unittest.TestCase):
-    def test_send(self):
+    def test_send_header(self):
         """
         Given one line of text,
-        When send() to an echoing server,
+        When send_header() to an echoing server,
         Then received message matches the original message.
         """
-        text = 'A very very simple text.'
-        msg = Message(text)
-        echo_server = Server()
+        def send_to_server():
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(0.0001)
+                s.connect(('127.0.0.1', 50001))
 
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.connect((echo_server.server_ip, echo_server.server_port))
+                client = Controller(s)
+                text = 'A message of 21 bytes'
+                msg = Message(text, client)
 
-            client = Controller(s)
+                ok, res = client.send_header(msg._header)
 
-            ok, res = client.send(msg)
+                self.assertTrue(ok)
+                self.assertIsNotNone(res)
+                self.assertEqual(res, b'21')
+                print(res)
 
-            self.assertTrue(ok)
-            self.assertIsNotNone(res)
+        echo_server = EchoServer('127.0.0.1', 50001)
+        t1 = Thread(target=echo_server.start)
+        t1.start()
+
+        t2 = Thread(target=send_to_server)
+        t2.start()
+        t2.join()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -55,3 +55,23 @@ class TestController(unittest.TestCase):
             self.assertIsNotNone(res)
             self.assertEqual(res, text)
             print(res)
+
+    def test_send_text_receive_dict(self):
+        """
+        Given path to a text file,
+        When send_text(), receive_dict(),
+        Then output matches the manually counted result.
+        """
+        file_path = '/Users/karlemstrand/Documents/git/HiQ/data/test_count_multiple_files/poly_line.txt'
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.connect(('star.karlemstrand.com', 50001))
+            client = Controller(s)
+
+            with open(file_path) as f:
+                for line in f:
+                    client.send_text(line)
+
+                    res = client.receive_dict()
+
+                    self.assertIsNotNone(res)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -68,10 +68,21 @@ class TestController(unittest.TestCase):
             s.connect(('star.karlemstrand.com', 50001))
             client = Controller(s)
 
+            word_frequency_dict = {}
             with open(file_path) as f:
                 for line in f:
                     client.send_text(line)
 
                     res = client.receive_dict()
 
-                    self.assertIsNotNone(res)
+                    for key, val in res.items():
+                        try:
+                            word_frequency_dict[key] += val
+                        except KeyError:
+                            word_frequency_dict[key] = val
+
+            # testing
+            self.assertEqual(word_frequency_dict['a'], 3)
+            self.assertEqual(word_frequency_dict['very'], 6)
+            self.assertEqual(word_frequency_dict['simple'], 3)
+            self.assertEqual(word_frequency_dict['text'], 3)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -32,3 +32,26 @@ class TestController(unittest.TestCase):
             self.assertIsNotNone(res)
             self.assertEqual(res, b'21')
             print(res)
+
+    def test_send_text(self):
+        """
+        Given one line of text,
+        When send_text() to an echoing server,
+        Then decoded received message matches the original text.
+        """
+        echo_server = EchoBaseServer('127.0.0.1', 50001)
+        t1 = Thread(target=echo_server.start)
+        t1.start()
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.connect(('127.0.0.1', 50001))
+
+            client = Controller(s)
+            text = 'A very very simple text.'
+
+            ok, res = client.send_text(text)
+
+            self.assertTrue(ok)
+            self.assertIsNotNone(res)
+            self.assertEqual(res, text)
+            print(res)

--- a/tests/test_local_counter.py
+++ b/tests/test_local_counter.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 
 from models.base_counter import BaseCounter
+from server import count_word_frequencies
 
 
 class TestLocalCounter(unittest.TestCase):
@@ -12,9 +13,8 @@ class TestLocalCounter(unittest.TestCase):
         Then output matches the manually counted result.
         """
         text = 'A very very simple text.'
-        base_counter = BaseCounter(text)
 
-        word_frequency_dict = base_counter.count_word_frequencies()
+        word_frequency_dict = count_word_frequencies(text)
 
         self.assertEqual(word_frequency_dict['a'], 1)
         self.assertEqual(word_frequency_dict['very'], 2)


### PR DESCRIPTION
# Description

The single threaded counter is now running on a server. It can be a remote one or a local one. The server communicates with the client using socket.

I would define the transmission protocol with protobuf, but considering the scope of this test, I skipped that.

Normally, the client sends a fixed length message specifying the length of the header. The header contains the length and type of the payload. Finally the payload is transmitted. Here I skipped the second part for simplicity (less handshakes).

This PR includes:
- Message class
- simple echo server copied from the internet
- function send_text, send_dict, receive_dict etc.
- code optimisations
- unit tests

## Type of change

- New feature
- This change requires a documentation update


# Testing

This PR involves and passes 6 unit tests. Test coverage 94% for models, 70% for controller and 38% for server.

![Skærmbillede 2022-05-19 kl  21 13 12](https://user-images.githubusercontent.com/2918707/169384586-72a3abb7-1714-485c-9167-fdb581e22a00.png)

# Checklist:

- [x] My code follows the style guidelines of this project (PEP8)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)
