### PR TITLE
Implement distributed computing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,40 @@
 # Polystar-Consultant-Interview
 
+# HiQ-Code-Interview
+
+### How to Run This Code
+
+To setup a conda env:
+```console
+karlemstrand@MSI-GS63:~$ conda update -n base conda
+karlemstrand@MSI-GS63:~$ conda create --name star-py39 python=3.9
+karlemstrand@MSI-GS63:~$ conda activate star-py39
+(star-py39) karlemstrand@MSI-GS63:~$ git clone https://github.com/rlindsberg/Polystar-Consultant-Interview.git && cd Polystar-Consultant-Interview
+$ python server.py -p 50001
+```
+In another terminal:
+```console
+$ python server.py -p 50000
+```
+In another terminal:
+```console
+$ python client.py
+```
+
+### Task
+- Two (2) servers shall read and expose one text file each. (frankenstein.txt and dracula.txt)
+- One (1) client shall read and count the data from the two servers in parallel. As a suggestion the communication between server and client use sockets.
+- The code should work just as well for very large files, thus do not keep entire files in memory at any time.
+- The result shall be one (1) print out of the 5 most common words in the two texts with the total number of occurrences of the word.
+
+### Description
 This program reads all files in a given directory and counts the most common words. Right now it runs locally with a single thread.
 
 The input files are dracula.txt and frankenstein.txt.
 
 The results are [('the', 12483), ('and', 9018), ('i', 7692), ('to', 6919), ('of', 6517)], which looks reasonable.
 
-The transmission protocol is as follows:
+### Transmission protocol
 
 send_text()
 1. client sends header - send_header()

--- a/client.py
+++ b/client.py
@@ -26,7 +26,7 @@ def count(host: str, port: int, file_path: str, lock: Lock):
             for line in tqdm(f):
                 client.send_text(line)
 
-                res = client.receive_dict()
+                ok, res = client.receive_dict()
 
                 with lock:
                     for key, val in res.items():

--- a/client.py
+++ b/client.py
@@ -1,0 +1,65 @@
+import json
+import socket
+from collections import Counter
+from threading import Thread, Lock
+from typing import Dict
+import re
+from typing import Dict
+from os import listdir
+from os.path import isfile, join
+from tqdm import tqdm
+
+from controller import Controller
+
+server_ip_list = ['poly.karlemstrand.com', 'star.karlemstrand.com']
+server_port_list = [50000, 50001]
+thread_list = []
+final_word_frequency_dict = {}
+
+
+def count(host: str, port: int, file_path: str, lock: Lock):
+    global final_word_frequency_dict
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((host, port))
+
+        client = Controller(s)
+
+        with open(file_path) as f:
+            print(file_path)
+            for line in tqdm(f):
+                client.send_text(line)
+
+                res = client.receive_dict()
+
+                with lock:
+                    for key, val in res.items():
+                        try:
+                            final_word_frequency_dict[key] += val
+                        except KeyError:
+                            final_word_frequency_dict[key] = val
+        print('Done!')
+
+
+def main():
+    data_path = '/Users/karlemstrand/Documents/git/HiQ/data/novels'
+    files = [join(data_path, f) for f in listdir(data_path) if isfile(join(data_path, f))]
+
+    for i, file_path in enumerate(files):
+        host = server_ip_list[i]
+        port = server_port_list[i]
+        lock = Lock()
+
+        t = Thread(target=count, args=(host, port, file_path, lock))
+        t.start()
+        thread_list.append(t)
+
+    for t in thread_list:
+        t.join()
+
+        top_k_counter = Counter(final_word_frequency_dict).most_common(5)
+        print(dict(top_k_counter))
+
+
+if __name__ == '__main__':
+    main()

--- a/client.py
+++ b/client.py
@@ -55,6 +55,8 @@ def main():
 
     top_k_counter = Counter(final_word_frequency_dict).most_common(5)
     top_k_dict = dict(top_k_counter)
+    print(f'The 5 most common words in the two texts are: {top_k_dict}')
+
     return top_k_dict
 
 

--- a/client.py
+++ b/client.py
@@ -1,10 +1,6 @@
-import json
 import socket
 from collections import Counter
 from threading import Thread, Lock
-from typing import Dict
-import re
-from typing import Dict
 from os import listdir
 from os.path import isfile, join
 from tqdm import tqdm

--- a/client.py
+++ b/client.py
@@ -57,8 +57,9 @@ def main():
     for t in thread_list:
         t.join()
 
-        top_k_counter = Counter(final_word_frequency_dict).most_common(5)
-        print(dict(top_k_counter))
+    top_k_counter = Counter(final_word_frequency_dict).most_common(5)
+    top_k_dict = dict(top_k_counter)
+    return top_k_dict
 
 
 if __name__ == '__main__':

--- a/controller.py
+++ b/controller.py
@@ -1,6 +1,6 @@
 import json
 import socket
-from typing import Tuple, Dict
+from typing import Tuple, Dict, Union
 
 from models.message import Message
 
@@ -12,10 +12,23 @@ class Controller:
     def __init__(self, socket_connection):
         self.conn = socket_connection
 
-    def _send_header(self, header_to_send: bytes) -> Tuple[bool, bytes]:
+    def receive_from_socket(self, length: int) -> Tuple[bool, Union[bytes, None]]:
+        try:
+            res = self.conn.recv(length)
+            return True, res
+
+        except ConnectionResetError:
+            return False, None
+
+    def _send_header(self, header_to_send: bytes) -> Tuple[bool, Union[bytes, None]]:
         try:
             self.conn.sendall(header_to_send)
-            res = self.conn.recv(1024)
+
+            # res = self.conn.recv(1024)
+            ok, res = self.receive_from_socket(1024)
+            if not ok:
+                return False, None
+
         except socket.timeout as e:
             print(e)
             res = None
@@ -26,54 +39,71 @@ class Controller:
         else:
             return False, res
 
-    def _send_payload(self, msg: Message) -> Tuple[bool, bytes]:
+    def _send_payload(self, msg: Message) -> Tuple[bool, Union[bytes, None]]:
         self.conn.sendall(msg.payload)
-        res = self.conn.recv(msg.length).decode(msg.encoding)
 
-        if res == msg.text:
+        # res = self.conn.recv(msg.length).decode(msg.encoding)
+        ok, res = self.receive_from_socket(msg.length)
+        if not ok:
+            return False, None
+
+        text = res.decode(msg.encoding)
+        if text == msg.text:
             return True, res
         else:
             return False, res
 
-    def send_text(self, text: str) -> Tuple[bool, bytes]:
+    def send_text(self, text: str) -> Tuple[bool, Union[str, None]]:
         msg = Message(text, self)
 
         ok, res = self._send_header(msg.header)
 
         if not ok:
-            raise Exception('Send header failed.')
+            print('Send header failed.')
+            return False, None
         else:
             # continue
             ok, res = self._send_payload(msg)
+            res = res.decode('utf-8')
 
             if not ok:
-                raise Exception('Send message payload failed.')
+                print('Send message payload failed.')
+                return False, None
             else:
                 return ok, res
 
-    def send_dict(self, json_dict: Dict) -> Tuple[bool, bytes]:
+    def send_dict(self, json_dict: Dict) -> Tuple[bool, Union[bytes, None]]:
         data = json.dumps(json_dict)
         msg = Message(data, self)
 
         ok, res = self._send_header(msg.header)
 
         if not ok:
-            raise Exception('Send header failed.')
+            print('Send header failed.')
+            return False, None
         else:
             # continue
             self._send_payload(msg)
 
             return ok, res
 
-    def receive_dict(self) -> Dict:
-        header = self.conn.recv(1024)
+    def receive_dict(self) -> Tuple[bool, Union[Dict, None]]:
+        # header = self.conn.recv(1024)
+        ok, header = self.receive_from_socket(1024)
+        if not ok:
+            return False, None
+
         self.conn.sendall(header)
         payload_size = int(header.decode('utf-8'))
 
         # client stores json dump, sends res - sendall()
-        data = self.conn.recv(payload_size)
+        # data = self.conn.recv(payload_size)
+        ok, data = self.receive_from_socket(payload_size)
+        if not ok:
+            return False, None
+
         self.conn.sendall(data)
 
         json_dict = json.loads(data)
 
-        return json_dict
+        return True, json_dict

--- a/controller.py
+++ b/controller.py
@@ -4,6 +4,8 @@ from typing import Tuple, Dict, Union
 
 from models.message import Message
 
+from models.codes import Codes
+
 
 class Controller:
     """
@@ -12,22 +14,22 @@ class Controller:
     def __init__(self, socket_connection):
         self.conn = socket_connection
 
-    def receive_from_socket(self, length: int) -> Tuple[bool, Union[bytes, None]]:
+    def receive_from_socket(self, length: int) -> Tuple[Codes, Union[bytes, None]]:
         try:
             res = self.conn.recv(length)
-            return True, res
+            return Codes.OK, res
 
         except ConnectionResetError:
-            return False, None
+            return Codes.ABORTED, None
 
-    def _send_header(self, header_to_send: bytes) -> Tuple[bool, Union[bytes, None]]:
+    def _send_header(self, header_to_send: bytes) -> Tuple[Codes, Union[bytes, None]]:
         try:
             self.conn.sendall(header_to_send)
 
             # res = self.conn.recv(1024)
             ok, res = self.receive_from_socket(1024)
-            if not ok:
-                return False, None
+            if ok != Codes.OK:
+                return Codes.ABORTED, None
 
         except socket.timeout as e:
             print(e)
@@ -35,63 +37,63 @@ class Controller:
 
         # Verify result
         if res == header_to_send:
-            return True, res
+            return Codes.OK, res
         else:
-            return False, res
+            return Codes.DATA_LOSS, res
 
-    def _send_payload(self, msg: Message) -> Tuple[bool, Union[bytes, None]]:
+    def _send_payload(self, msg: Message) -> Tuple[Codes, Union[bytes, None]]:
         self.conn.sendall(msg.payload)
 
         # res = self.conn.recv(msg.length).decode(msg.encoding)
         ok, res = self.receive_from_socket(msg.length)
-        if not ok:
-            return False, None
+        if ok != Codes.OK:
+            return Codes.ABORTED, None
 
         text = res.decode(msg.encoding)
         if text == msg.text:
-            return True, res
+            return Codes.OK, res
         else:
-            return False, res
+            return Codes.DATA_LOSS, res
 
-    def send_text(self, text: str) -> Tuple[bool, Union[str, None]]:
+    def send_text(self, text: str) -> Tuple[Codes, Union[str, None]]:
         msg = Message(text, self)
 
         ok, res = self._send_header(msg.header)
 
-        if not ok:
+        if ok != Codes.OK:
             print('Send header failed.')
-            return False, None
+            return ok, None
         else:
             # continue
             ok, res = self._send_payload(msg)
             res = res.decode('utf-8')
 
-            if not ok:
+            if ok != Codes.OK:
                 print('Send message payload failed.')
-                return False, None
+                return ok, None
             else:
                 return ok, res
 
-    def send_dict(self, json_dict: Dict) -> Tuple[bool, Union[bytes, None]]:
+    def send_dict(self, json_dict: Dict) -> Tuple[Codes, Union[bytes, None]]:
         data = json.dumps(json_dict)
         msg = Message(data, self)
 
         ok, res = self._send_header(msg.header)
 
-        if not ok:
+        if ok != Codes.OK:
             print('Send header failed.')
-            return False, None
+            return ok, None
         else:
             # continue
             self._send_payload(msg)
 
             return ok, res
 
-    def receive_dict(self) -> Tuple[bool, Union[Dict, None]]:
+    def receive_dict(self) -> Tuple[Codes, Union[Dict, None]]:
         # header = self.conn.recv(1024)
         ok, header = self.receive_from_socket(1024)
-        if not ok:
-            return False, None
+        if ok != Codes.OK:
+            return ok, None
 
         self.conn.sendall(header)
         payload_size = int(header.decode('utf-8'))
@@ -99,11 +101,11 @@ class Controller:
         # client stores json dump, sends res - sendall()
         # data = self.conn.recv(payload_size)
         ok, data = self.receive_from_socket(payload_size)
-        if not ok:
-            return False, None
+        if ok != Codes.OK:
+            return ok, None
 
         self.conn.sendall(data)
 
         json_dict = json.loads(data)
 
-        return True, json_dict
+        return ok, json_dict

--- a/models/base_server.py
+++ b/models/base_server.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 
 
 class BaseServer(ABC):
-    def __init__(self, server_ip, server_port):
+    def __init__(self, server_ip: str, server_port: int):
         self.server_ip = server_ip
         self.server_port = server_port
 

--- a/models/codes.py
+++ b/models/codes.py
@@ -1,0 +1,47 @@
+from enum import Enum
+from grpc import StatusCode
+
+
+class Codes(Enum):
+    """
+    OK: Not an error; returned on success
+    CANCELLED: The operation was cancelled (typically by the caller).
+    UNKNOWN: Unknown error.
+    INVALID_ARGUMENT: Client specified an invalid argument.
+    DEADLINE_EXCEEDED: Deadline expired before operation could complete.
+    NOT_FOUND: Some requested entity (e.g., file or directory) was not found.
+    ALREADY_EXISTS: Some entity that we attempted to create (e.g., file or directory)
+    already exists.
+    PERMISSION_DENIED: The caller does not have permission to execute the specified
+    operation.
+    UNAUTHENTICATED: The request does not have valid authentication credentials for the
+    operation.
+    RESOURCE_EXHAUSTED: Some resource has been exhausted, perhaps a per-user quota, or
+    perhaps the entire file system is out of space.
+    FAILED_PRECONDITION: Operation was rejected because the system is not in a state
+    required for the operation's execution.
+    ABORTED: The operation was aborted, typically due to a concurrency issue
+    like sequencer check failures, transaction aborts, etc.
+    UNIMPLEMENTED: Operation is not implemented or not supported/enabled in this service.
+    INTERNAL: Internal errors.  Means some invariants expected by underlying
+    system has been broken.
+    UNAVAILABLE: The service is currently unavailable.
+    DATA_LOSS: Unrecoverable data loss or corruption.
+    """
+    OK = 0
+    CANCELLED = 1
+    UNKNOWN = 2
+    INVALID_ARGUMENT = 3
+    DEADLINE_EXCEEDED = 4
+    NOT_FOUND = 5
+    ALREADY_EXISTS = 6
+    PERMISSION_DENIED = 7
+    RESOURCE_EXHAUSTED = 8
+    FAILED_PRECONDITION = 9
+    ABORTED = 10
+    OUT_OF_RANGE = 11
+    UNIMPLEMENTED = 12
+    INTERNAL = 13
+    UNAVAILABLE = 14
+    DATA_LOSS = 15
+    UNAUTHENTICATED = 16

--- a/models/echo_server.py
+++ b/models/echo_server.py
@@ -6,7 +6,7 @@ from models.base_server import BaseServer
 
 
 class EchoBaseServer(BaseServer):
-    def __init__(self, server_ip, server_port):
+    def __init__(self, server_ip: str, server_port: int):
         super().__init__(server_ip, server_port)
 
     def start(self):

--- a/models/message.py
+++ b/models/message.py
@@ -1,7 +1,8 @@
+from typing import Union
 
 
 class Message:
-    def __init__(self, text, controller):
+    def __init__(self, text: Union[bytes, str], controller):
         self.encoding = 'utf-8'
         self._text = text
         self._payload = self._text.encode(self.encoding)

--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import socket
 from collections import Counter
@@ -13,10 +14,10 @@ def count_word_frequencies(text: str) -> Dict:
     return dict(fre_list)
 
 
-def start():
+def start(port):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
 
-        s.bind(('127.0.0.1', 50000))
+        s.bind(('127.0.0.1', port))
         s.listen()
 
         while True:
@@ -47,4 +48,9 @@ def start():
 
 
 if __name__ == '__main__':
-    start()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--port', default=50000, type=int, help='The socket port')
+    args = parser.parse_args()
+
+    start(args.port)

--- a/server.py
+++ b/server.py
@@ -27,7 +27,7 @@ def start(port):
             data_received = controller.conn.recv(1024)
             # while socket is open
             while data_received != b'':
-                # print(f'2. I got {data_received}')
+                print(f'2. I got {data_received}')
                 payload_size = int(data_received.decode('utf-8'))
 
                 controller.conn.sendall(data_received)
@@ -40,7 +40,9 @@ def start(port):
                 text = payload.decode('utf-8')
                 f_dict = count_word_frequencies(text)
 
-                controller.send_dict(f_dict)
+                ok, res = controller.send_dict(f_dict)
+                if not ok:
+                    return
 
                 # the very end, wait for next packet
                 data_received = controller.conn.recv(1024)
@@ -51,4 +53,5 @@ if __name__ == '__main__':
     parser.add_argument('-p', '--port', default=50000, type=int, help='The socket port')
     args = parser.parse_args()
 
-    start(args.port)
+    while True:
+        start(args.port)

--- a/server.py
+++ b/server.py
@@ -16,7 +16,7 @@ def count_word_frequencies(text: str) -> Dict:
 def start():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
 
-        s.bind((socket.gethostname(), 50001))
+        s.bind(('127.0.0.1', 50000))
         s.listen()
 
         while True:
@@ -34,13 +34,11 @@ def start():
 
                 # 5. server stores payload, sends res - sendall()
                 payload = controller.conn.recv(payload_size)
-                print(f'5. I got {payload}')
                 controller.conn.sendall(payload)
 
                 # server computes word frequency
                 text = payload.decode('utf-8')
                 f_dict = count_word_frequencies(text)
-                print(f_dict)
 
                 controller.send_dict(f_dict)
 

--- a/server.py
+++ b/server.py
@@ -27,7 +27,7 @@ def start(port):
             data_received = controller.conn.recv(1024)
             # while socket is open
             while data_received != b'':
-                print(f'2. I got {data_received}')
+                # print(f'2. I got {data_received}')
                 payload_size = int(data_received.decode('utf-8'))
 
                 controller.conn.sendall(data_received)

--- a/server.py
+++ b/server.py
@@ -1,8 +1,7 @@
 import argparse
-import json
-import socket
 from collections import Counter
 import re
+import socket
 from typing import Dict
 
 from controller import Controller
@@ -48,7 +47,6 @@ def start(port):
 
 
 if __name__ == '__main__':
-
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--port', default=50000, type=int, help='The socket port')
     args = parser.parse_args()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,30 @@
+import time
 import unittest
-
+from threading import Thread
 import client
+
+import server
 
 
 class TestController(unittest.TestCase):
     def test_final_results(self):
+        # setup two servers
+        threads = []
+        server_port_list = [50000, 50001]
+        n_threads = 2
+
+        for i in range(n_threads):
+            t = Thread(target=server.start, args=(server_port_list[i],))
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+
+        time.sleep(1)
+
+        # count
         word_frequency_dict_top_5 = client.main()
 
+        # test
         ground_truth = {'the': 12483, 'and': 9018, 'i': 7692, 'to': 6919, 'of': 6517}
-
         self.assertEqual(word_frequency_dict_top_5, ground_truth)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,12 @@
+import unittest
+
+import client
+
+
+class TestController(unittest.TestCase):
+    def test_final_results(self):
+        word_frequency_dict_top_5 = client.run()
+
+        ground_truth = {'the': 12483, 'and': 9018, 'i': 7692, 'to': 6919, 'of': 6517}
+
+        self.assertEqual(word_frequency_dict_top_5, ground_truth)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,20 +8,6 @@ import server
 
 class TestController(unittest.TestCase):
     def test_final_results(self):
-        # setup two servers
-        threads = []
-        server_port_list = [50000, 50001]
-        n_threads = 2
-
-        for i in range(n_threads):
-            t = Thread(target=server.start, args=(server_port_list[i],))
-            threads.append(t)
-
-        for t in threads:
-            t.start()
-
-        time.sleep(1)
-
         # count
         word_frequency_dict_top_5 = client.main()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ import client
 
 class TestController(unittest.TestCase):
     def test_final_results(self):
-        word_frequency_dict_top_5 = client.run()
+        word_frequency_dict_top_5 = client.main()
 
         ground_truth = {'the': 12483, 'and': 9018, 'i': 7692, 'to': 6919, 'of': 6517}
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -26,7 +26,7 @@ class TestController(unittest.TestCase):
             text = 'A message of 21 bytes'
             msg = Message(text, client)
 
-            ok, res = client.send_header(msg._header)
+            ok, res = client._send_header(msg._header)
 
             self.assertTrue(ok)
             self.assertIsNotNone(res)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -14,13 +14,13 @@ class TestController(unittest.TestCase):
         When send_header() to an echoing server,
         Then received message matches the original message.
         """
-        echo_server = EchoBaseServer('127.0.0.1', 50001)
+        echo_server = EchoBaseServer('127.0.0.1', 50008)
         t1 = Thread(target=echo_server.start)
         t1.start()
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(1)
-            s.connect(('127.0.0.1', 50001))
+            s.connect(('127.0.0.1', 50008))
 
             client = Controller(s)
             text = 'A message of 21 bytes'
@@ -65,7 +65,7 @@ class TestController(unittest.TestCase):
         file_path = '/Users/karlemstrand/Documents/git/HiQ/data/test_count_multiple_files/poly_line.txt'
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.connect(('star.karlemstrand.com', 50001))
+            s.connect(('star.karlemstrand.com', 50009))
             client = Controller(s)
 
             word_frequency_dict = {}

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -14,13 +14,13 @@ class TestController(unittest.TestCase):
         When send_header() to an echoing server,
         Then received message matches the original message.
         """
-        echo_server = EchoBaseServer('127.0.0.1', 50008)
+        echo_server = EchoBaseServer('127.0.0.1', 30001)
         t1 = Thread(target=echo_server.start)
         t1.start()
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(1)
-            s.connect(('127.0.0.1', 50008))
+            s.connect(('127.0.0.1', 30001))
 
             client = Controller(s)
             text = 'A message of 21 bytes'
@@ -39,12 +39,12 @@ class TestController(unittest.TestCase):
         When send_text() to an echoing server,
         Then decoded received message matches the original text.
         """
-        echo_server = EchoBaseServer('127.0.0.1', 50001)
+        echo_server = EchoBaseServer('127.0.0.1', 30002)
         t1 = Thread(target=echo_server.start)
         t1.start()
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.connect(('127.0.0.1', 50001))
+            s.connect(('127.0.0.1', 30002))
 
             client = Controller(s)
             text = 'A very very simple text.'
@@ -65,7 +65,12 @@ class TestController(unittest.TestCase):
         file_path = '/Users/karlemstrand/Documents/git/HiQ/data/test_count_multiple_files/poly_line.txt'
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.connect(('star.karlemstrand.com', 50009))
+            try:
+                s.connect(('star.karlemstrand.com', 50000))
+            except ConnectionRefusedError:
+                print('Please setup a counting server listening at port 50000 by running $ python server.py -p 50000')
+            except BrokenPipeError:
+                print('Connection was dropped. Please try again.')
             client = Controller(s)
 
             word_frequency_dict = {}
@@ -73,7 +78,7 @@ class TestController(unittest.TestCase):
                 for line in f:
                     client.send_text(line)
 
-                    res = client.receive_dict()
+                    ok, res = client.receive_dict()
 
                     for key, val in res.items():
                         try:

--- a/tests/test_local_counter.py
+++ b/tests/test_local_counter.py
@@ -64,6 +64,11 @@ class TestLocalCounter(unittest.TestCase):
             self.assertEqual(word_frequency_dict['texta'], 2)
 
     def test_count_word_in_two_novels(self):
+        """
+        Given path to the directory containing the novels,
+        When count_word_frequencies_in_directory(),
+        Then output is not None and top 5 occurrence > 0.
+        """
         data_path = '/Users/karlemstrand/Documents/git/HiQ/data/novels'
         base_counter = BaseCounter(data_path=data_path)
 


### PR DESCRIPTION
# Description

The client can now distribute the word-counting tasks to two servers through socket.

User can setup as many servers as port limit allows from the terminal using $ python server.py -p <socket port>

This PR includes:
- a client script to load text files and send them line by line to servers
- a server script to listen on specified port. It receives the text, counts word frequencies and sends the results back to the client
- code optimisations
- unit tests

## Type of change

- New feature
- This change requires a documentation update


# Testing

This PR involves and passes 7 unit tests. Test coverage:

![Skærmbillede 2022-05-20 kl  08 32 47](https://user-images.githubusercontent.com/2918707/169467237-c8e2328e-9d5d-472f-be2a-83e8ffc78d25.png)


# Checklist:

- [x] My code follows the style guidelines of this project (PEP8)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)
